### PR TITLE
Script to download a document as plain text

### DIFF
--- a/gdoc2latex.py
+++ b/gdoc2latex.py
@@ -59,7 +59,7 @@ def fetchGoogleDoc(urlOrGdocFile,email='',password=''):
     # find the doc url
     if urlOrGdocFile.startswith("https://"):
         url = urlOrGdocFile
-    elif urlOrGdocFile.endswith(".gdoc"):
+    elif urlOrGdocFile.endswith(".gdoc") or urlOrGdocFile.endswith(".gddoc"):
         filename = urlOrGdocFile
         f = open(filename, "r")
         content = json.load(f)
@@ -69,7 +69,11 @@ def fetchGoogleDoc(urlOrGdocFile,email='',password=''):
         raise Exception(str(urlOrGdocFile) + " not a google doc URL or .gdoc filename")
     # pull out the document id
     try:
-        docId = re.search("/document/d/([^/]+)/", url).group(1)
+        result = re.search("/document/d/([^/]+)/|/open\?id=([^&/]+)", url)
+        docId = result.group(1) or result.group(2)
+        # Two possible formats (2017-10-03):
+        # https://drive.google.com/open?id=idididid
+        # https://docs.google.com/document/d/idididid/edit?usp=sharing
     except Exception:
         raise Exception("can't find a google document ID in " + str(urlOrGdocFile))
     # construct an export URL

--- a/gdoc2text.py
+++ b/gdoc2text.py
@@ -1,0 +1,40 @@
+
+# Note that the Google Drive REST API v3 is great for downloading files in a range of formats
+# using the HTTP Accept header (e.g. Accept: text/plain).
+# https://developers.google.com/drive/v3/web/manage-downloads#downloading_google_documents
+
+"""
+usage:
+  python gdoc2text.py <URL> [<username>]
+  python gdoc2text.py <.gdoc or .gddoc filename> [<username>]
+
+example:
+  python gdoc2text.py https://docs.google.com/document/d/1yEyXxtEeQ5_E7PibjYpofPC6kP4jMG-EieKhwkK7oQE/edit
+  python gdoc2text.py test.gddoc
+
+example for private documents:
+  python gdoc2text.py https://docs.google.com/document/d/1yEyXxtEeQ5_E7PibjYpofPC6kP4jMG-EieKhwkK7oQE/edit USERNAME
+"""
+
+from gdoc2latex import fetchGoogleDoc, html_to_text
+import getpass
+import sys
+
+def main():
+    arg_count = len(sys.argv) - 1
+    if arg_count == 0 or arg_count > 2:
+        sys.stderr.write(__doc__)
+        sys.exit(1)
+
+    if arg_count == 1:
+        html = fetchGoogleDoc(sys.argv[1])
+    else:
+        password = getpass.getpass()
+        html = fetchGoogleDoc(sys.argv[1], sys.argv[2], password)
+
+    text = html_to_text(html)
+    sys.stdout.write(text)
+
+
+if __name__ == '__main__':
+    main()

--- a/gdoc2text.py
+++ b/gdoc2text.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python2.7
+# gdoc2latex.py uses Python 2.7 syntax.
 
 # Note that the Google Drive REST API v3 is great for downloading files in a range of formats
 # using the HTTP Accept header (e.g. Accept: text/plain).


### PR DESCRIPTION
I need to manage a shared plain-text file and Google Docs seems to be a good choice to edit the file. It only lacks a scriptable plain-text downloader, so I forked this repo.

I also updated some of your code:

- The new file extension for text documents seems to be `.gddoc`. The JSON content of the files seem to be compatible, the script still works.
- When I share a file from Google Drive, the first share link displayed is different from the link the script expects. So I added this URL format.